### PR TITLE
removed self test from probe function

### DIFF
--- a/drivers/sensor/adxl367/adxl367.c
+++ b/drivers/sensor/adxl367/adxl367.c
@@ -912,11 +912,6 @@ static int adxl367_probe(const struct device *dev)
 	data->act_proc_mode = ADXL367_LOOPED;
 #endif
 
-	ret = adxl367_self_test(dev);
-	if (ret != 0) {
-		return ret;
-	}
-
 	ret = adxl367_temp_read_en(dev, cfg->temp_en);
 	if (ret != 0) {
 		return ret;


### PR DESCRIPTION
### Outline: 
Removes the self test from the initialization function within the ADXL367 driver. It is not possible to ensure at initialization that the device is static in order to run the self test. Therefore it was removed from the init function. It will be externed from the driver to be used in the application layer in our project. 

### Testing: 
Tested this change by making sure that the self test pass/fail logs are not present when the device initializes (before putting the self test in the applicaiton layer). 
